### PR TITLE
Add simple runnable example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ tradingEngine := trengin.New(strategy, broker)
 tradingEngine.Run(context.TODO())
 ```
 
+### Runnable example
+
+See [examples/simple](examples/simple) for a small working example. It uses an in-memory broker,
+so it does not connect to a real trading account, but it shows how a strategy sends actions,
+waits for results, and reacts to engine callbacks.
+
+```shell
+go run ./examples/simple
+```
+
 ## Main types
 
 | Name             | Description                                                                                |

--- a/examples/simple/broker.go
+++ b/examples/simple/broker.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/evsamsonov/trengin/v2"
+)
+
+var errPositionNotFound = errors.New("position not found")
+
+type memoryBroker struct {
+	mu         sync.Mutex
+	openPrice  float64
+	closePrice float64
+	positions  map[trengin.PositionID]*memoryPosition
+}
+
+type memoryPosition struct {
+	position trengin.Position
+	closed   chan trengin.Position
+}
+
+func newMemoryBroker(openPrice float64, closePrice float64) *memoryBroker {
+	return &memoryBroker{
+		openPrice:  openPrice,
+		closePrice: closePrice,
+		positions:  make(map[trengin.PositionID]*memoryPosition),
+	}
+}
+
+func (b *memoryBroker) OpenPosition(
+	ctx context.Context,
+	action trengin.OpenPositionAction,
+) (trengin.Position, trengin.PositionClosed, error) {
+	select {
+	case <-ctx.Done():
+		return trengin.Position{}, nil, ctx.Err()
+	default:
+	}
+
+	position, err := trengin.NewPosition(action, time.Now(), b.openPrice)
+	if err != nil {
+		return trengin.Position{}, nil, fmt.Errorf("create position: %w", err)
+	}
+
+	closed := make(chan trengin.Position, 1)
+
+	b.mu.Lock()
+	b.positions[position.ID] = &memoryPosition{
+		position: *position,
+		closed:   closed,
+	}
+	b.mu.Unlock()
+
+	return *position, closed, nil
+}
+
+func (b *memoryBroker) ChangeConditionalOrder(
+	ctx context.Context,
+	action trengin.ChangeConditionalOrderAction,
+) (trengin.Position, error) {
+	select {
+	case <-ctx.Done():
+		return trengin.Position{}, ctx.Err()
+	default:
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	stored, ok := b.positions[action.PositionID]
+	if !ok {
+		return trengin.Position{}, fmt.Errorf("find position: %w", errPositionNotFound)
+	}
+
+	if action.StopLoss != 0 {
+		stored.position.StopLoss = action.StopLoss
+	}
+	if action.TakeProfit != 0 {
+		stored.position.TakeProfit = action.TakeProfit
+	}
+
+	return stored.position, nil
+}
+
+func (b *memoryBroker) ClosePosition(
+	ctx context.Context,
+	action trengin.ClosePositionAction,
+) (trengin.Position, error) {
+	select {
+	case <-ctx.Done():
+		return trengin.Position{}, ctx.Err()
+	default:
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	stored, ok := b.positions[action.PositionID]
+	if !ok {
+		return trengin.Position{}, fmt.Errorf("find position: %w", errPositionNotFound)
+	}
+
+	if err := stored.position.Close(time.Now(), b.closePrice); err != nil {
+		return trengin.Position{}, fmt.Errorf("close position: %w", err)
+	}
+
+	stored.closed <- stored.position
+	close(stored.closed)
+	delete(b.positions, action.PositionID)
+
+	return stored.position, nil
+}

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -2,22 +2,16 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"sync"
-	"time"
+	"log"
+	"os"
 
 	"github.com/evsamsonov/trengin/v2"
 )
 
-const figi = "BBG004730N88"
-
 func main() {
 	ctx := context.Background()
-
-	strategy := demoStrategy{}
-	broker := newMemoryBroker(100, 108)
-	engine := trengin.New(strategy, broker)
+	engine := trengin.New(demoStrategy{}, newMemoryBroker(100, 108))
 
 	engine.
 		OnPositionOpened(func(position trengin.Position) {
@@ -47,163 +41,7 @@ func main() {
 		})
 
 	if err := engine.Run(ctx); err != nil {
-		panic(err)
+		log.Printf("Failed to run trading engine: %v", err)
+		os.Exit(1)
 	}
-}
-
-type demoStrategy struct{}
-
-func (s demoStrategy) Run(ctx context.Context, actions trengin.Actions) error {
-	openAction := trengin.NewOpenPositionAction(figi, trengin.Long, 1, 5, 10)
-	if err := sendAction(ctx, actions, openAction); err != nil {
-		return err
-	}
-
-	openResult, err := openAction.Result(ctx)
-	if err != nil {
-		return err
-	}
-
-	changeAction := trengin.NewChangeConditionalOrderAction(
-		openResult.Position.ID,
-		openResult.Position.OpenPrice-3,
-		openResult.Position.OpenPrice+12,
-	)
-	if err := sendAction(ctx, actions, changeAction); err != nil {
-		return err
-	}
-	if _, err := changeAction.Result(ctx); err != nil {
-		return err
-	}
-
-	closeAction := trengin.NewClosePositionAction(openResult.Position.ID)
-	if err := sendAction(ctx, actions, closeAction); err != nil {
-		return err
-	}
-	if _, err := closeAction.Result(ctx); err != nil {
-		return err
-	}
-
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-openResult.Closed:
-	}
-
-	close(actions)
-	<-ctx.Done()
-	return nil
-}
-
-func sendAction(ctx context.Context, actions trengin.Actions, action interface{}) error {
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case actions <- action:
-		return nil
-	}
-}
-
-type memoryBroker struct {
-	mu         sync.Mutex
-	openPrice  float64
-	closePrice float64
-	positions  map[trengin.PositionID]*memoryPosition
-}
-
-type memoryPosition struct {
-	position trengin.Position
-	closed   chan trengin.Position
-}
-
-func newMemoryBroker(openPrice, closePrice float64) *memoryBroker {
-	return &memoryBroker{
-		openPrice:  openPrice,
-		closePrice: closePrice,
-		positions:  make(map[trengin.PositionID]*memoryPosition),
-	}
-}
-
-func (b *memoryBroker) OpenPosition(
-	ctx context.Context,
-	action trengin.OpenPositionAction,
-) (trengin.Position, trengin.PositionClosed, error) {
-	select {
-	case <-ctx.Done():
-		return trengin.Position{}, nil, ctx.Err()
-	default:
-	}
-
-	position, err := trengin.NewPosition(action, time.Now(), b.openPrice)
-	if err != nil {
-		return trengin.Position{}, nil, err
-	}
-
-	closed := make(chan trengin.Position, 1)
-
-	b.mu.Lock()
-	b.positions[position.ID] = &memoryPosition{
-		position: *position,
-		closed:   closed,
-	}
-	b.mu.Unlock()
-
-	return *position, closed, nil
-}
-
-func (b *memoryBroker) ChangeConditionalOrder(
-	ctx context.Context,
-	action trengin.ChangeConditionalOrderAction,
-) (trengin.Position, error) {
-	select {
-	case <-ctx.Done():
-		return trengin.Position{}, ctx.Err()
-	default:
-	}
-
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
-	memoryPosition, ok := b.positions[action.PositionID]
-	if !ok {
-		return trengin.Position{}, errors.New("position not found")
-	}
-
-	if action.StopLoss != 0 {
-		memoryPosition.position.StopLoss = action.StopLoss
-	}
-	if action.TakeProfit != 0 {
-		memoryPosition.position.TakeProfit = action.TakeProfit
-	}
-
-	return memoryPosition.position, nil
-}
-
-func (b *memoryBroker) ClosePosition(
-	ctx context.Context,
-	action trengin.ClosePositionAction,
-) (trengin.Position, error) {
-	select {
-	case <-ctx.Done():
-		return trengin.Position{}, ctx.Err()
-	default:
-	}
-
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
-	memoryPosition, ok := b.positions[action.PositionID]
-	if !ok {
-		return trengin.Position{}, errors.New("position not found")
-	}
-
-	if err := memoryPosition.position.Close(time.Now(), b.closePrice); err != nil {
-		return trengin.Position{}, err
-	}
-
-	memoryPosition.closed <- memoryPosition.position
-	close(memoryPosition.closed)
-	delete(b.positions, action.PositionID)
-
-	return memoryPosition.position, nil
 }

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/evsamsonov/trengin/v2"
+)
+
+const figi = "BBG004730N88"
+
+func main() {
+	ctx := context.Background()
+
+	strategy := demoStrategy{}
+	broker := newMemoryBroker(100, 108)
+	engine := trengin.New(strategy, broker)
+
+	engine.
+		OnPositionOpened(func(position trengin.Position) {
+			fmt.Printf(
+				"opened: figi=%s price=%.2f stop=%.2f take=%.2f\n",
+				position.FIGI,
+				position.OpenPrice,
+				position.StopLoss,
+				position.TakeProfit,
+			)
+		}).
+		OnConditionalOrderChanged(func(position trengin.Position) {
+			fmt.Printf(
+				"changed: figi=%s stop=%.2f take=%.2f\n",
+				position.FIGI,
+				position.StopLoss,
+				position.TakeProfit,
+			)
+		}).
+		OnPositionClosed(func(position trengin.Position) {
+			fmt.Printf(
+				"closed: figi=%s price=%.2f profit=%.2f\n",
+				position.FIGI,
+				position.ClosePrice,
+				position.Profit(),
+			)
+		})
+
+	if err := engine.Run(ctx); err != nil {
+		panic(err)
+	}
+}
+
+type demoStrategy struct{}
+
+func (s demoStrategy) Run(ctx context.Context, actions trengin.Actions) error {
+	defer close(actions)
+
+	openAction := trengin.NewOpenPositionAction(figi, trengin.Long, 1, 5, 10)
+	if err := sendAction(ctx, actions, openAction); err != nil {
+		return err
+	}
+
+	openResult, err := openAction.Result(ctx)
+	if err != nil {
+		return err
+	}
+
+	changeAction := trengin.NewChangeConditionalOrderAction(
+		openResult.Position.ID,
+		openResult.Position.OpenPrice-3,
+		openResult.Position.OpenPrice+12,
+	)
+	if err := sendAction(ctx, actions, changeAction); err != nil {
+		return err
+	}
+	if _, err := changeAction.Result(ctx); err != nil {
+		return err
+	}
+
+	closeAction := trengin.NewClosePositionAction(openResult.Position.ID)
+	if err := sendAction(ctx, actions, closeAction); err != nil {
+		return err
+	}
+	if _, err := closeAction.Result(ctx); err != nil {
+		return err
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-openResult.Closed:
+		return nil
+	}
+}
+
+func sendAction(ctx context.Context, actions trengin.Actions, action interface{}) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case actions <- action:
+		return nil
+	}
+}
+
+type memoryBroker struct {
+	mu         sync.Mutex
+	openPrice  float64
+	closePrice float64
+	positions  map[trengin.PositionID]*memoryPosition
+}
+
+type memoryPosition struct {
+	position trengin.Position
+	closed   chan trengin.Position
+}
+
+func newMemoryBroker(openPrice, closePrice float64) *memoryBroker {
+	return &memoryBroker{
+		openPrice:  openPrice,
+		closePrice: closePrice,
+		positions:  make(map[trengin.PositionID]*memoryPosition),
+	}
+}
+
+func (b *memoryBroker) OpenPosition(
+	ctx context.Context,
+	action trengin.OpenPositionAction,
+) (trengin.Position, trengin.PositionClosed, error) {
+	select {
+	case <-ctx.Done():
+		return trengin.Position{}, nil, ctx.Err()
+	default:
+	}
+
+	position, err := trengin.NewPosition(action, time.Now(), b.openPrice)
+	if err != nil {
+		return trengin.Position{}, nil, err
+	}
+
+	closed := make(chan trengin.Position, 1)
+
+	b.mu.Lock()
+	b.positions[position.ID] = &memoryPosition{
+		position: *position,
+		closed:   closed,
+	}
+	b.mu.Unlock()
+
+	return *position, closed, nil
+}
+
+func (b *memoryBroker) ChangeConditionalOrder(
+	ctx context.Context,
+	action trengin.ChangeConditionalOrderAction,
+) (trengin.Position, error) {
+	select {
+	case <-ctx.Done():
+		return trengin.Position{}, ctx.Err()
+	default:
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	memoryPosition, ok := b.positions[action.PositionID]
+	if !ok {
+		return trengin.Position{}, errors.New("position not found")
+	}
+
+	if action.StopLoss != 0 {
+		memoryPosition.position.StopLoss = action.StopLoss
+	}
+	if action.TakeProfit != 0 {
+		memoryPosition.position.TakeProfit = action.TakeProfit
+	}
+
+	return memoryPosition.position, nil
+}
+
+func (b *memoryBroker) ClosePosition(
+	ctx context.Context,
+	action trengin.ClosePositionAction,
+) (trengin.Position, error) {
+	select {
+	case <-ctx.Done():
+		return trengin.Position{}, ctx.Err()
+	default:
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	memoryPosition, ok := b.positions[action.PositionID]
+	if !ok {
+		return trengin.Position{}, errors.New("position not found")
+	}
+
+	if err := memoryPosition.position.Close(time.Now(), b.closePrice); err != nil {
+		return trengin.Position{}, err
+	}
+
+	memoryPosition.closed <- memoryPosition.position
+	close(memoryPosition.closed)
+	delete(b.positions, action.PositionID)
+
+	return memoryPosition.position, nil
+}

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -54,8 +54,6 @@ func main() {
 type demoStrategy struct{}
 
 func (s demoStrategy) Run(ctx context.Context, actions trengin.Actions) error {
-	defer close(actions)
-
 	openAction := trengin.NewOpenPositionAction(figi, trengin.Long, 1, 5, 10)
 	if err := sendAction(ctx, actions, openAction); err != nil {
 		return err
@@ -90,8 +88,11 @@ func (s demoStrategy) Run(ctx context.Context, actions trengin.Actions) error {
 	case <-ctx.Done():
 		return ctx.Err()
 	case <-openResult.Closed:
-		return nil
 	}
+
+	close(actions)
+	<-ctx.Done()
+	return nil
 }
 
 func sendAction(ctx context.Context, actions trengin.Actions, action interface{}) error {

--- a/examples/simple/strategy.go
+++ b/examples/simple/strategy.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/evsamsonov/trengin/v2"
+)
+
+const demoFIGI = "BBG004730N88"
+
+type demoStrategy struct{}
+
+func (s demoStrategy) Run(ctx context.Context, actions trengin.Actions) error {
+	openAction := trengin.NewOpenPositionAction(demoFIGI, trengin.Long, 1, 5, 10)
+	if err := sendAction(ctx, actions, openAction); err != nil {
+		return fmt.Errorf("send open action: %w", err)
+	}
+
+	openResult, err := openAction.Result(ctx)
+	if err != nil {
+		return fmt.Errorf("open position result: %w", err)
+	}
+
+	changeAction := trengin.NewChangeConditionalOrderAction(
+		openResult.Position.ID,
+		openResult.Position.OpenPrice-3,
+		openResult.Position.OpenPrice+12,
+	)
+	if err = sendAction(ctx, actions, changeAction); err != nil {
+		return fmt.Errorf("send change action: %w", err)
+	}
+
+	if _, err = changeAction.Result(ctx); err != nil {
+		return fmt.Errorf("change conditional order result: %w", err)
+	}
+
+	closeAction := trengin.NewClosePositionAction(openResult.Position.ID)
+	if err = sendAction(ctx, actions, closeAction); err != nil {
+		return fmt.Errorf("send close action: %w", err)
+	}
+
+	if _, err = closeAction.Result(ctx); err != nil {
+		return fmt.Errorf("close position result: %w", err)
+	}
+
+	select {
+	case <-ctx.Done():
+		return fmt.Errorf("wait position closed: %w", ctx.Err())
+	case <-openResult.Closed:
+	}
+
+	close(actions)
+	<-ctx.Done()
+	return nil
+}
+
+func sendAction(ctx context.Context, actions trengin.Actions, action interface{}) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case actions <- action:
+		return nil
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a runnable in-memory example under `examples/simple`
- split the example into thin `main`, strategy, and memory broker files following `.cursor/rules/go-backend.mdc`
- wrap action/result errors with short tags and avoid shadowing the `memoryPosition` type
- merge latest `master` (including go-backend rules and lint/toolchain updates)

## Verification
- `go test ./...`
- `go run ./examples/simple`
- `golangci-lint run --fix --timeout=5m ./...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1950-0502-77b1-860e-dbf760572711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1950-0502-77b1-860e-dbf760572711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

